### PR TITLE
chore: mask landing email behind Hide-My-Email relay

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,7 +103,7 @@
 							<ul>
 								<li><a href="https://github.com/velesnitski/CV#alex-velesnitski" class="icon brands fa-github"><span class="label">Github</span></a></li>
 								<li><a href="https://www.linkedin.com/in/velesnitski/" class="icon brands fa-linkedin-in"><span class="label">LinkedIn</span></a></li>
-								<li><a href="mailto:velesnitski@gmail.com" class="icon solid fa-envelope"><span class="label">Business Email</span></a></li>
+								<li><a href="mailto:pawls.driller7o@icloud.com" class="icon solid fa-envelope"><span class="label">Business Email</span></a></li>
 								<!-- Guthub button. -->
 								<li class="github-followers">
 									<a class="github-button" href="https://github.com/velesnitski" 


### PR DESCRIPTION
## Summary

Switches the envelope `mailto:` on the landing page from the primary gmail to an iCloud Hide-My-Email alias.

## Why

The mailto on `index.html:106` is rendered only as an envelope icon, but the address itself sits in HTML source — easily harvested by scrapers. The relay forwards to the same inbox and is revocable on demand, so any spam flood can be killed without touching the brand-aligned gmail used everywhere else (LinkedIn, GitHub, CV README badge).

## Scope

- Single-line change in `index.html`
- No visual change (icon-only link)
- CV README badge intentionally left as `velesnitski@gmail.com` for trust signals

## Test plan

- [ ] Click envelope icon on the live page — composer opens with the relay address
- [ ] Send test email to the relay — verify it lands in the gmail inbox via Apple's iCloud Settings
- [ ] Confirm CV README badge still shows the gmail